### PR TITLE
feat: Validate server response status code.

### DIFF
--- a/src/ShopList/index.js
+++ b/src/ShopList/index.js
@@ -35,15 +35,22 @@ export const ShopList = (props) => {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${localStorage.getItem('token')}`,
       },
-    }).then((response) => response.json())
-      .then((data) => {
+    }).then((response) => {
+      if (response.status === 201) {
+        return response.json()
+      } else if (response.status === 401) {
+        throw "Neautorizované volání API. Pravděpodobně nemáš uveden autentizační token v Local storage."
+      } else {
+        throw `Server vrátil chybový návratový kód ${response.status} ${response.statusText}`
+      }
+    }).then((data) => {
         element.replaceWith(
           ShopList({
             day: day,
             dayResult: data.result,
           })
         );
-      });
+    }).catch(error => element.innerHTML = `<div style="color: red; font-weight: bold;">${error}</div>`);
 
     return element;
   }


### PR DESCRIPTION
Co si myslíte o téhle úpravě? Dnes na lekci JS2 minimálně půlka účastníků skončila na tom, že neměli v prohlížeči v Local storage uložený token pro volání API. S čímž dosavadní kód nepočítal, takže pak aplikace hlásí chybu ve smyslu „Cannot read dayName from undefined“, z čehož není snadné odvodit, že chybí token v Local storage.
Na druhou stranu je v kódu `throw` a `catch()`, což účastnice kurzu neznají, což také není dobré. Nebo ten kód ještě upravit, aby tam nebylo `throw` a `catch()`? Sice to bude divné ošetření chybového stavu, ale aspoň by účastnice rozuměly kódu, který tam bude.